### PR TITLE
Add JSON-LD structured data for content pages

### DIFF
--- a/src/pages/BlogPost.tsx
+++ b/src/pages/BlogPost.tsx
@@ -57,14 +57,30 @@ export function BlogPost() {
   if (!article) {
     return null;
   }
+  const jsonLd = {
+    '@context': 'https://schema.org',
+    '@type': 'Article',
+    headline: article.title,
+    datePublished: article.published_at || article.created_at,
+    image: article.featured_image,
+    author: {
+      '@type': 'Organization',
+      name: 'Nexius Labs'
+    }
+  };
 
   return (
-    <div className="min-h-screen bg-nexius-dark-bg">
-      {/* Hero Section */}
-      <div className="relative h-[60vh] min-h-[400px] bg-nexius-navy">
-        {article.featured_image && (
-          <div className="absolute inset-0">
-            <img
+    <>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+      />
+      <div className="min-h-screen bg-nexius-dark-bg">
+        {/* Hero Section */}
+        <div className="relative h-[60vh] min-h-[400px] bg-nexius-navy">
+          {article.featured_image && (
+            <div className="absolute inset-0">
+              <img
               src={article.featured_image}
               alt={article.title}
               className="w-full h-full object-cover opacity-20"
@@ -132,5 +148,6 @@ export function BlogPost() {
         </div>
       </section>
     </div>
+    </>
   );
 }

--- a/src/pages/CaseStudy.tsx
+++ b/src/pages/CaseStudy.tsx
@@ -203,14 +203,29 @@ export function CaseStudy() {
       </div>
     );
   }
+  const jsonLd = {
+    '@context': 'https://schema.org',
+    '@type': 'Article',
+    headline: study.title,
+    image: study.image,
+    author: {
+      '@type': 'Organization',
+      name: 'Nexius Labs'
+    }
+  };
 
   return (
-    <div className="min-h-screen bg-nexius-dark-bg">
-      {/* Hero Section */}
-      <div className="relative h-[60vh] min-h-[400px] bg-nexius-navy">
-        <div className="absolute inset-0">
-          <img
-            src={study.image}
+    <>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+      />
+      <div className="min-h-screen bg-nexius-dark-bg">
+        {/* Hero Section */}
+        <div className="relative h-[60vh] min-h-[400px] bg-nexius-navy">
+          <div className="absolute inset-0">
+            <img
+              src={study.image}
             alt={study.title}
             className="w-full h-full object-cover opacity-20"
           />
@@ -366,5 +381,6 @@ export function CaseStudy() {
         </div>
       </div>
     </div>
+    </>
   );
 }

--- a/src/pages/EventDetail.tsx
+++ b/src/pages/EventDetail.tsx
@@ -75,13 +75,34 @@ export function EventDetail() {
       </div>
     );
   }
+  const jsonLd = {
+    '@context': 'https://schema.org',
+    '@type': 'Event',
+    name: event.title,
+    startDate: event.start_date,
+    endDate: event.end_date,
+    location: {
+      '@type': 'Place',
+      name: event.location
+    },
+    image: event.featured_image,
+    organizer: {
+      '@type': 'Organization',
+      name: 'Nexius Labs'
+    }
+  };
 
   return (
-    <div className="min-h-screen bg-nexius-dark-bg">
-      {/* Hero Section */}
-      <div className="relative bg-nexius-navy py-16">
-        <div className="relative max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 h-full">
-          <Link 
+    <>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+      />
+      <div className="min-h-screen bg-nexius-dark-bg">
+        {/* Hero Section */}
+        <div className="relative bg-nexius-navy py-16">
+          <div className="relative max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 h-full">
+            <Link
             to="/events" 
             className="inline-flex items-center text-white/80 hover:text-white pt-8 transition-colors"
           >
@@ -178,13 +199,14 @@ export function EventDetail() {
             </div>
           </div>
         </div>
-      </div>
-      
+        </div>
+
       <EventRegistrationForm
         event={event}
         isOpen={showRegistration}
         onClose={() => setShowRegistration(false)}
       />
-    </div>
+      </div>
+    </>
   );
 }


### PR DESCRIPTION
## Summary
- inject schema.org JSON-LD metadata for blog articles
- add Event schema JSON-LD to event detail pages
- include structured data for case studies

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ad1dffcf9c832084863fc139be7fb2