### PR TITLE
feat: add react-helmet-async for page metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "pdf-parse": "^1.1.1",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
+    "react-helmet-async": "^1.3.0",
     "react-router-dom": "^6.22.1"
   },
   "devDependencies": {

--- a/src/components/SEO.tsx
+++ b/src/components/SEO.tsx
@@ -1,0 +1,37 @@
+import { Helmet } from 'react-helmet-async';
+
+interface SEOProps {
+  title: string;
+  description: string;
+  canonical: string;
+  image?: string;
+  type?: string;
+}
+
+const DEFAULT_IMAGE = 'https://nexiuslabs.com/images/hero.png';
+
+export function SEO({
+  title,
+  description,
+  canonical,
+  image = DEFAULT_IMAGE,
+  type = 'website',
+}: SEOProps) {
+  return (
+    <Helmet>
+      <title>{title}</title>
+      <meta name="description" content={description} />
+      <link rel="canonical" href={canonical} />
+      <meta property="og:title" content={title} />
+      <meta property="og:description" content={description} />
+      <meta property="og:url" content={canonical} />
+      <meta property="og:type" content={type} />
+      {image && <meta property="og:image" content={image} />}
+      <meta name="twitter:card" content="summary_large_image" />
+      <meta name="twitter:title" content={title} />
+      <meta name="twitter:description" content={description} />
+      {image && <meta name="twitter:image" content={image} />}
+    </Helmet>
+  );
+}
+

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,13 +1,17 @@
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import { BrowserRouter } from 'react-router-dom';
+import { HelmetProvider } from 'react-helmet-async';
 import App from './App.tsx';
 import './index.css';
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <BrowserRouter>
-      <App />
-    </BrowserRouter>
+    <HelmetProvider>
+      <BrowserRouter>
+        <App />
+      </BrowserRouter>
+    </HelmetProvider>
   </StrictMode>
 );
+

--- a/src/pages/AIIgnite.tsx
+++ b/src/pages/AIIgnite.tsx
@@ -19,12 +19,19 @@ import {
 } from 'lucide-react';
 import { ContactForm } from '../components/ContactForm';
 import { FeatureCard } from '../components/FeatureCard';
+import { SEO } from '../components/SEO';
 
 export function AIIgnite() {
   const [showContactForm, setShowContactForm] = useState(false);
+  const baseUrl = 'https://nexiuslabs.com';
 
   return (
     <div className="min-h-screen bg-nexius-dark-bg">
+      <SEO
+        title="AI Ignite – NEXIUS Labs"
+        description="Premier event series connecting business leaders with AI innovators to drive real-world impact and competitive advantage."
+        canonical={`${baseUrl}/ai-ignite`}
+      />
       {/* Hero Section */}
       <section className="relative pt-32 pb-24 bg-gradient-to-b from-nexius-navy to-nexius-navy/95">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 text-center">

--- a/src/pages/AdminPage.tsx
+++ b/src/pages/AdminPage.tsx
@@ -40,6 +40,7 @@ import {
 import { ImageUpload } from '../components/ImageUpload';
 import { ArticleEditor } from '../components/ArticleEditor';
 import type { Image, Article, Lead, ChatSession, ChatMessage } from '../types/database';
+import { SEO } from '../components/SEO';
 
 const SECTIONS = [
   { id: 'images', name: 'Images', Icon: ImageIcon, description: 'Upload and manage your website images.' },
@@ -1020,6 +1021,11 @@ export default function AdminPage() {
 
   return (
     <div className="min-h-screen bg-nexius-dark-bg">
+      <SEO
+        title="Admin Dashboard | NEXIUS Labs"
+        description="Administration panel for NEXIUS Labs."
+        canonical="https://nexiuslabs.com/admin"
+      />
       {/* Header */}
       <header className="bg-nexius-dark-surface border-b border-nexius-dark-border fixed w-full z-10">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">

--- a/src/pages/Blog.tsx
+++ b/src/pages/Blog.tsx
@@ -3,10 +3,12 @@ import { Link } from 'react-router-dom';
 import { supabase } from '../lib/supabase';
 import { Clock, ArrowRight, Calendar, User } from 'lucide-react';
 import type { Article } from '../types/database';
+import { SEO } from '../components/SEO';
 
 export function Blog() {
   const [articles, setArticles] = useState<Article[]>([]);
   const [loading, setLoading] = useState(true);
+  const baseUrl = 'https://nexiuslabs.com';
 
   useEffect(() => {
     loadArticles();
@@ -39,6 +41,11 @@ export function Blog() {
 
   return (
     <div className="min-h-screen bg-nexius-dark-bg">
+      <SEO
+        title="NEXIUS Labs Blog"
+        description="Insights, tutorials, and updates from our team of AI experts"
+        canonical={`${baseUrl}/blog`}
+      />
       {/* Hero Section */}
       <section className="relative pt-32 pb-24 bg-gradient-to-b from-nexius-navy to-nexius-navy/95">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">

--- a/src/pages/BlogPost.tsx
+++ b/src/pages/BlogPost.tsx
@@ -3,12 +3,14 @@ import { useParams, Link, useNavigate } from 'react-router-dom';
 import { supabase } from '../lib/supabase';
 import { ArrowLeft, Calendar, User, Clock } from 'lucide-react';
 import type { Article } from '../types/database';
+import { SEO } from '../components/SEO';
 
 export function BlogPost() {
   const { slug } = useParams<{ slug: string }>();
   const navigate = useNavigate();
   const [article, setArticle] = useState<Article | null>(null);
   const [loading, setLoading] = useState(true);
+  const baseUrl = 'https://nexiuslabs.com';
 
   useEffect(() => {
     loadArticle();
@@ -57,9 +59,17 @@ export function BlogPost() {
   if (!article) {
     return null;
   }
+  const canonical = `${baseUrl}/blog/${slug}`;
 
   return (
     <div className="min-h-screen bg-nexius-dark-bg">
+      <SEO
+        title={`${article.title} | NEXIUS Labs`}
+        description={article.description || ''}
+        canonical={canonical}
+        image={article.featured_image || undefined}
+        type="article"
+      />
       {/* Hero Section */}
       <div className="relative h-[60vh] min-h-[400px] bg-nexius-navy">
         {article.featured_image && (

--- a/src/pages/CaseStudies.tsx
+++ b/src/pages/CaseStudies.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
 import { ArrowRight, TrendingUp, Users, Target, Clock } from 'lucide-react';
+import { SEO } from '../components/SEO';
 
 const caseStudies = [
   {
@@ -30,8 +31,14 @@ const caseStudies = [
 ];
 
 export function CaseStudies() {
+  const baseUrl = 'https://nexiuslabs.com';
   return (
     <div className="min-h-screen bg-nexius-dark-bg">
+      <SEO
+        title="AI Case Studies | NEXIUS Labs"
+        description="Discover how businesses leverage our AI solutions to achieve remarkable results."
+        canonical={`${baseUrl}/case-studies`}
+      />
       {/* Hero Section */}
       <section className="relative pt-32 pb-24 bg-gradient-to-b from-nexius-navy to-nexius-navy/95">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">

--- a/src/pages/CaseStudy.tsx
+++ b/src/pages/CaseStudy.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect } from 'react';
 import { useParams, Link } from 'react-router-dom';
 import { ArrowLeft, CheckCircle2, TrendingUp, Users, Target, ArrowRight } from 'lucide-react';
+import { SEO } from '../components/SEO';
 
 interface CaseStudyData {
   title: string;
@@ -185,6 +186,7 @@ const caseStudiesData: Record<string, CaseStudyData> = {
 export function CaseStudy() {
   const { id } = useParams<{ id: string }>();
   const study = id ? caseStudiesData[id] : null;
+  const baseUrl = 'https://nexiuslabs.com';
 
   // Scroll to top when component mounts
   useEffect(() => {
@@ -203,9 +205,17 @@ export function CaseStudy() {
       </div>
     );
   }
+  const canonical = `${baseUrl}/case-study/${id}`;
 
   return (
     <div className="min-h-screen bg-nexius-dark-bg">
+      <SEO
+        title={`${study.title} | NEXIUS Labs Case Study`}
+        description={study.description}
+        canonical={canonical}
+        image={study.image}
+        type="article"
+      />
       {/* Hero Section */}
       <div className="relative h-[60vh] min-h-[400px] bg-nexius-navy">
         <div className="absolute inset-0">

--- a/src/pages/EventDetail.tsx
+++ b/src/pages/EventDetail.tsx
@@ -5,6 +5,7 @@ import { supabase } from '../lib/supabase';
 import { Calendar, Clock, MapPin, Users, ArrowLeft } from 'lucide-react';
 import { EventRegistrationForm } from '../components/EventRegistrationForm';
 import type { Event } from '../types/database';
+import { SEO } from '../components/SEO';
 
 export function EventDetail() {
   const { slug } = useParams<{ slug: string }>();
@@ -12,6 +13,7 @@ export function EventDetail() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [showRegistration, setShowRegistration] = useState(false);
+  const baseUrl = 'https://nexiuslabs.com';
 
   useEffect(() => {
     loadEvent();
@@ -77,8 +79,17 @@ export function EventDetail() {
     );
   }
 
+  const canonical = `${baseUrl}/event/${slug}`;
+
   return (
     <div className="min-h-screen bg-nexius-dark-bg">
+      <SEO
+        title={`${event.title} | NEXIUS Labs Event`}
+        description={event.description || ''}
+        canonical={canonical}
+        image={event.featured_image || undefined}
+        type="article"
+      />
       {/* Hero Section */}
       <div className="relative bg-nexius-navy py-16">
         <div className="relative max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 h-full">

--- a/src/pages/Events.tsx
+++ b/src/pages/Events.tsx
@@ -3,12 +3,14 @@ import { supabase } from '../lib/supabase';
 import { EventsList } from '../components/EventsList';
 import { Clock, Calendar, ArrowRight } from 'lucide-react';
 import type { Event } from '../types/database';
+import { SEO } from '../components/SEO';
 
 export default function Events() {
   const [events, setEvents] = useState<Event[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [filter, setFilter] = useState<'upcoming' | 'past'>('upcoming');
+  const baseUrl = 'https://nexiuslabs.com';
 
   useEffect(() => {
     loadEvents();
@@ -50,6 +52,11 @@ export default function Events() {
 
   return (
     <div className="min-h-screen bg-nexius-dark-bg">
+      <SEO
+        title="Events | NEXIUS Labs"
+        description="Join workshops, webinars, and conferences focused on AI innovation and business transformation."
+        canonical={`${baseUrl}/events`}
+      />
       {/* Hero Section */}
       <section className="relative pt-32 pb-24 bg-gradient-to-b from-nexius-navy to-nexius-navy/95">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">

--- a/src/pages/LinksPage.tsx
+++ b/src/pages/LinksPage.tsx
@@ -15,6 +15,7 @@ import {
   Calendar, 
   UserPlus,
 } from 'lucide-react';
+import { SEO } from '../components/SEO';
 
 interface SocialLink {
   id: string;
@@ -97,6 +98,7 @@ const links: SocialLink[] = [
 
 export function LinksPage() {
   const [clickCount, setClickCount] = useState<Record<string, number>>({});
+  const baseUrl = 'https://nexiuslabs.com';
 
   useEffect(() => {
     // Load click counts from Supabase
@@ -132,6 +134,11 @@ export function LinksPage() {
 
   return (
     <div className="min-h-screen bg-gradient-to-b from-nexius-navy to-nexius-navy/95">
+      <SEO
+        title="NEXIUS Labs Links"
+        description="Connect with NEXIUS Labs and schedule a discovery call."
+        canonical={`${baseUrl}/links`}
+      />
       <HeroAnimation />
       {/* Header */}
       <header className="pt-12 px-4 sm:px-6 lg:px-8 flex justify-center">

--- a/src/pages/NotFound.tsx
+++ b/src/pages/NotFound.tsx
@@ -1,10 +1,17 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
 import { Home, ArrowLeft } from 'lucide-react';
+import { SEO } from '../components/SEO';
 
 export function NotFound() {
+  const baseUrl = 'https://nexiuslabs.com';
   return (
     <div className="min-h-screen bg-gradient-to-b from-nexius-navy to-nexius-navy/95 flex items-center justify-center px-4">
+      <SEO
+        title="Page Not Found | NEXIUS Labs"
+        description="The page you're looking for doesn't exist or has been moved."
+        canonical={`${baseUrl}/404`}
+      />
       <div className="max-w-md w-full text-center">
         <img
           src="https://tunidbyclygzipvbfzee.supabase.co/storage/v1/object/public/website-images/m04h4fs8wns-1739784195705.png"

--- a/src/pages/PrivacyPolicy.tsx
+++ b/src/pages/PrivacyPolicy.tsx
@@ -1,10 +1,17 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
 import { ArrowLeft } from 'lucide-react';
+import { SEO } from '../components/SEO';
 
 export function PrivacyPolicy() {
+  const baseUrl = 'https://nexiuslabs.com';
   return (
     <div className="min-h-screen bg-nexius-dark-bg">
+      <SEO
+        title="Privacy Policy | NEXIUS Labs"
+        description="Read the privacy practices of NEXIUS Labs."
+        canonical={`${baseUrl}/privacy`}
+      />
       {/* Header */}
       <div className="bg-nexius-navy py-16">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">

--- a/src/pages/UploadLogo.tsx
+++ b/src/pages/UploadLogo.tsx
@@ -1,9 +1,11 @@
 import React, { useState } from 'react';
 import { ImageUpload } from '../components/ImageUpload';
+import { SEO } from '../components/SEO';
 
 export function UploadLogo() {
   const [logoUrl, setLogoUrl] = useState<string | null>(null);
   const [uploadType, setUploadType] = useState<'melverick' | 'darryl'>('melverick');
+  const baseUrl = 'https://nexiuslabs.com';
 
   const handleUploadComplete = (imageUrl: string) => {
     setLogoUrl(imageUrl);
@@ -11,6 +13,11 @@ export function UploadLogo() {
 
   return (
     <div className="min-h-screen bg-nexius-dark-bg py-32">
+      <SEO
+        title="Upload Co-founder Photos | NEXIUS Labs"
+        description="Upload images for Nexius Labs co-founders."
+        canonical={`${baseUrl}/upload`}
+      />
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         <div className="max-w-3xl mx-auto">
           <div className="bg-nexius-dark-surface rounded-lg shadow-sm p-8 border border-nexius-dark-border">


### PR DESCRIPTION
## Summary
- install `react-helmet-async` and configure root provider
- add reusable `SEO` component to manage meta tags
- integrate dynamic metadata across blog posts, case studies, events, and static pages

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 62 errors, 5 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68ad0252938c8320a36a33b12913cef7