### PR TITLE
feat: add SEO metadata with react-helmet

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -39,6 +39,7 @@
         "pdf-parse": "^1.1.1",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
+        "react-helmet-async": "^2.0.5",
         "react-router-dom": "^6.22.1"
       },
       "devDependencies": {
@@ -3845,6 +3846,15 @@
       "resolved": "https://registry.npmjs.org/inline-style-parser/-/inline-style-parser-0.2.4.tgz",
       "integrity": "sha512-0aO8FkhNZlj/ZIbNi7Lxxr12obT7cL1moPfE4tg1LkX7LlLfC6DeX4l2ZEud1ukP9jNQyNnfzQVqwbwmAATY4Q=="
     },
+    "node_modules/invariant": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
+      "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.0.0"
+      }
+    },
     "node_modules/is-binary-path": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
@@ -5217,6 +5227,26 @@
         "react": "^18.3.1"
       }
     },
+    "node_modules/react-fast-compare": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-3.2.2.tgz",
+      "integrity": "sha512-nsO+KSNgo1SbJqJEYRE9ERzo7YtYbou/OqjSQKxV7jcKox7+usiUVZOAC+XnDOABXggQTno0Y1CpVnuWEc1boQ==",
+      "license": "MIT"
+    },
+    "node_modules/react-helmet-async": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/react-helmet-async/-/react-helmet-async-2.0.5.tgz",
+      "integrity": "sha512-rYUYHeus+i27MvFE+Jaa4WsyBKGkL6qVgbJvSBoX8mbsWoABJXdEO0bZyi0F6i+4f0NuIb8AvqPMj3iXFHkMwg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "invariant": "^2.2.4",
+        "react-fast-compare": "^3.2.2",
+        "shallowequal": "^1.1.0"
+      },
+      "peerDependencies": {
+        "react": "^16.6.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
     "node_modules/react-property": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/react-property/-/react-property-2.0.2.tgz",
@@ -5413,6 +5443,12 @@
       "bin": {
         "semver": "bin/semver.js"
       }
+    },
+    "node_modules/shallowequal": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/shallowequal/-/shallowequal-1.1.0.tgz",
+      "integrity": "sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ==",
+      "license": "MIT"
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "pdf-parse": "^1.1.1",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
+    "react-helmet-async": "^2.0.5",
     "react-router-dom": "^6.22.1"
   },
   "devDependencies": {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { Link, Routes, Route } from 'react-router-dom';
+import { Link, Routes, Route, useLocation } from 'react-router-dom';
 import { supabase } from './lib/supabase';
 import {
   Menu,
@@ -41,6 +41,7 @@ import { PrivacyPolicy } from './pages/PrivacyPolicy';
 import { Events } from './pages/Events';
 import { NotFound } from './pages/NotFound';
 import { Chat } from './components/Chat';
+import { Helmet } from 'react-helmet-async';
 
 const features = [
   {
@@ -271,6 +272,7 @@ function Navigation({ onContactClick }: { onContactClick: () => void }) {
 }
 
 function HomePage() {
+  const location = useLocation();
   const scrollToTop = () => {
     window.scrollTo({
       top: 0,
@@ -278,8 +280,31 @@ function HomePage() {
     });
   };
 
+  const canonicalUrl = `https://nexiuslabs.com${location.pathname}`;
+
   return (
-    <div className="min-h-screen bg-nexius-dark-bg">
+    <>
+      <Helmet>
+        <title>NEXIUS Labs | AI-Powered Executive Intelligence Platform</title>
+        <meta
+          name="description"
+          content="Nexius Labs specializes in AI-powered business automation, process optimization, and no-code solutions to help businesses scale efficiently."
+        />
+        <link rel="canonical" href={canonicalUrl} />
+        <meta property="og:title" content="NEXIUS Labs | AI-Powered Executive Intelligence Platform" />
+        <meta
+          property="og:description"
+          content="Nexius Labs specializes in AI-powered business automation, process optimization, and no-code solutions to help businesses scale efficiently."
+        />
+        <meta property="og:url" content={canonicalUrl} />
+        <meta name="twitter:card" content="summary_large_image" />
+        <meta name="twitter:title" content="NEXIUS Labs | AI-Powered Executive Intelligence Platform" />
+        <meta
+          name="twitter:description"
+          content="Nexius Labs specializes in AI-powered business automation, process optimization, and no-code solutions to help businesses scale efficiently."
+        />
+      </Helmet>
+      <div className="min-h-screen bg-nexius-dark-bg">
       {/* Hero Section */}
       <section className="relative pt-32 pb-24 bg-gradient-to-b from-nexius-navy to-nexius-navy/95">
         <HeroAnimation />
@@ -531,9 +556,9 @@ function HomePage() {
         </div>
       </footer>
     </div>
+    </>
   );
 }
-import { useLocation } from 'react-router-dom';
 
 export default function App() {
   const [isContactFormOpen, setIsContactFormOpen] = useState(false);

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,13 +1,16 @@
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import { BrowserRouter } from 'react-router-dom';
+import { HelmetProvider } from 'react-helmet-async';
 import App from './App.tsx';
 import './index.css';
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <BrowserRouter>
-      <App />
-    </BrowserRouter>
+    <HelmetProvider>
+      <BrowserRouter>
+        <App />
+      </BrowserRouter>
+    </HelmetProvider>
   </StrictMode>
 );

--- a/src/pages/AIIgnite.tsx
+++ b/src/pages/AIIgnite.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { Link } from 'react-router-dom';
+import { Link, useLocation } from 'react-router-dom';
 import { supabase } from '../lib/supabase';
 import {
   Target,
@@ -15,12 +15,36 @@ import {
 } from 'lucide-react';
 import { ContactForm } from '../components/ContactForm';
 import { FeatureCard } from '../components/FeatureCard';
+import { Helmet } from 'react-helmet-async';
 
 export function AIIgnite() {
   const [showContactForm, setShowContactForm] = useState(false);
+  const location = useLocation();
+  const canonicalUrl = `https://nexiuslabs.com${location.pathname}`;
 
   return (
-    <div className="min-h-screen bg-nexius-dark-bg">
+    <>
+      <Helmet>
+        <title>AI Ignite | NEXIUS Labs</title>
+        <meta
+          name="description"
+          content="AI Ignite connects business leaders with AI innovators to drive real-world impact and growth."
+        />
+        <link rel="canonical" href={canonicalUrl} />
+        <meta property="og:title" content="AI Ignite | NEXIUS Labs" />
+        <meta
+          property="og:description"
+          content="AI Ignite connects business leaders with AI innovators to drive real-world impact and growth."
+        />
+        <meta property="og:url" content={canonicalUrl} />
+        <meta name="twitter:card" content="summary_large_image" />
+        <meta name="twitter:title" content="AI Ignite | NEXIUS Labs" />
+        <meta
+          name="twitter:description"
+          content="AI Ignite connects business leaders with AI innovators to drive real-world impact and growth."
+        />
+      </Helmet>
+      <div className="min-h-screen bg-nexius-dark-bg">
       {/* Hero Section */}
       <section className="relative pt-32 pb-24 bg-gradient-to-b from-nexius-navy to-nexius-navy/95">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 text-center">
@@ -468,5 +492,6 @@ export function AIIgnite() {
         </div>
       </footer>
     </div>
+    </>
   );
 }

--- a/src/pages/AdminPage.tsx
+++ b/src/pages/AdminPage.tsx
@@ -31,6 +31,8 @@ import {
 import { ImageUpload } from '../components/ImageUpload';
 import { ArticleEditor } from '../components/ArticleEditor';
 import type { Image, Article, Lead, ChatSession, ChatMessage } from '../types/database';
+import { useLocation } from 'react-router-dom';
+import { Helmet } from 'react-helmet-async';
 
 const SECTIONS = [
   { id: 'images', name: 'Images', Icon: ImageIcon, description: 'Upload and manage your website images.' },
@@ -60,6 +62,7 @@ const EmptyState = ({ section, actionButton }: { section: typeof SECTIONS[0], ac
 );
 
 export default function AdminPage() {
+  const location = useLocation();
   const [session, setSession] = useState(null);
   const [activeSection, setActiveSection] = useState('images');
   const [editingImage, setEditingImage] = useState<Image | null>(null);
@@ -1004,8 +1007,22 @@ export default function AdminPage() {
     return <Auth />;
   }
 
+  const canonicalUrl = `https://nexiuslabs.com${location.pathname}`;
+
   return (
-    <div className="min-h-screen bg-nexius-dark-bg">
+    <>
+      <Helmet>
+        <title>Admin | NEXIUS Labs</title>
+        <meta name="description" content="Admin dashboard for managing site content" />
+        <link rel="canonical" href={canonicalUrl} />
+        <meta property="og:title" content="Admin | NEXIUS Labs" />
+        <meta property="og:description" content="Admin dashboard for managing site content" />
+        <meta property="og:url" content={canonicalUrl} />
+        <meta name="twitter:card" content="summary_large_image" />
+        <meta name="twitter:title" content="Admin | NEXIUS Labs" />
+        <meta name="twitter:description" content="Admin dashboard for managing site content" />
+      </Helmet>
+      <div className="min-h-screen bg-nexius-dark-bg">
       {/* Header */}
       <header className="bg-nexius-dark-surface border-b border-nexius-dark-border fixed w-full z-10">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
@@ -1097,6 +1114,7 @@ export default function AdminPage() {
         </div>
       </main>
     </div>
+    </>
   );
 }
 

--- a/src/pages/Blog.tsx
+++ b/src/pages/Blog.tsx
@@ -1,12 +1,14 @@
 import React, { useState, useEffect } from 'react';
-import { Link } from 'react-router-dom';
+import { Link, useLocation } from 'react-router-dom';
 import { supabase } from '../lib/supabase';
 import { Clock, ArrowRight, Calendar, User } from 'lucide-react';
 import type { Article } from '../types/database';
+import { Helmet } from 'react-helmet-async';
 
 export function Blog() {
   const [articles, setArticles] = useState<Article[]>([]);
   const [loading, setLoading] = useState(true);
+  const location = useLocation();
 
   useEffect(() => {
     loadArticles();
@@ -37,8 +39,31 @@ export function Blog() {
     });
   };
 
+  const canonicalUrl = `https://nexiuslabs.com${location.pathname}`;
+
   return (
-    <div className="min-h-screen bg-nexius-dark-bg">
+    <>
+      <Helmet>
+        <title>Blog | NEXIUS Labs</title>
+        <meta
+          name="description"
+          content="Insights, tutorials, and updates from our team of AI experts"
+        />
+        <link rel="canonical" href={canonicalUrl} />
+        <meta property="og:title" content="Blog | NEXIUS Labs" />
+        <meta
+          property="og:description"
+          content="Insights, tutorials, and updates from our team of AI experts"
+        />
+        <meta property="og:url" content={canonicalUrl} />
+        <meta name="twitter:card" content="summary_large_image" />
+        <meta name="twitter:title" content="Blog | NEXIUS Labs" />
+        <meta
+          name="twitter:description"
+          content="Insights, tutorials, and updates from our team of AI experts"
+        />
+      </Helmet>
+      <div className="min-h-screen bg-nexius-dark-bg">
       {/* Hero Section */}
       <section className="relative pt-32 pb-24 bg-gradient-to-b from-nexius-navy to-nexius-navy/95">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
@@ -140,5 +165,6 @@ export function Blog() {
         </div>
       </section>
     </div>
+    </>
   );
 }

--- a/src/pages/BlogPost.tsx
+++ b/src/pages/BlogPost.tsx
@@ -1,12 +1,14 @@
 import React, { useState, useEffect } from 'react';
-import { useParams, Link, useNavigate } from 'react-router-dom';
+import { useParams, Link, useNavigate, useLocation } from 'react-router-dom';
 import { supabase } from '../lib/supabase';
 import { ArrowLeft, Calendar, User, Clock } from 'lucide-react';
 import type { Article } from '../types/database';
+import { Helmet } from 'react-helmet-async';
 
 export function BlogPost() {
   const { slug } = useParams<{ slug: string }>();
   const navigate = useNavigate();
+  const location = useLocation();
   const [article, setArticle] = useState<Article | null>(null);
   const [loading, setLoading] = useState(true);
 
@@ -58,8 +60,34 @@ export function BlogPost() {
     return null;
   }
 
+  const canonicalUrl = `https://nexiuslabs.com${location.pathname}`;
+
   return (
-    <div className="min-h-screen bg-nexius-dark-bg">
+    <>
+      <Helmet>
+        <title>{`${article.title} | NEXIUS Labs`}</title>
+        {article.description && (
+          <meta name="description" content={article.description} />
+        )}
+        <link rel="canonical" href={canonicalUrl} />
+        <meta property="og:title" content={article.title} />
+        {article.description && (
+          <meta property="og:description" content={article.description} />
+        )}
+        <meta property="og:url" content={canonicalUrl} />
+        {article.featured_image && (
+          <meta property="og:image" content={article.featured_image} />
+        )}
+        <meta name="twitter:card" content="summary_large_image" />
+        <meta name="twitter:title" content={article.title} />
+        {article.description && (
+          <meta name="twitter:description" content={article.description} />
+        )}
+        {article.featured_image && (
+          <meta name="twitter:image" content={article.featured_image} />
+        )}
+      </Helmet>
+      <div className="min-h-screen bg-nexius-dark-bg">
       {/* Hero Section */}
       <div className="relative h-[60vh] min-h-[400px] bg-nexius-navy">
         {article.featured_image && (
@@ -132,5 +160,6 @@ export function BlogPost() {
         </div>
       </section>
     </div>
+    </>
   );
 }

--- a/src/pages/CaseStudies.tsx
+++ b/src/pages/CaseStudies.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
-import { Link } from 'react-router-dom';
+import { Link, useLocation } from 'react-router-dom';
 import { ArrowRight, TrendingUp, Users, Target, Clock } from 'lucide-react';
+import { Helmet } from 'react-helmet-async';
 
 const caseStudies = [
   {
@@ -30,8 +31,32 @@ const caseStudies = [
 ];
 
 export function CaseStudies() {
+  const location = useLocation();
+  const canonicalUrl = `https://nexiuslabs.com${location.pathname}`;
+
   return (
-    <div className="min-h-screen bg-nexius-dark-bg">
+    <>
+      <Helmet>
+        <title>Case Studies | NEXIUS Labs</title>
+        <meta
+          name="description"
+          content="Success stories of businesses transforming with our AI solutions"
+        />
+        <link rel="canonical" href={canonicalUrl} />
+        <meta property="og:title" content="Case Studies | NEXIUS Labs" />
+        <meta
+          property="og:description"
+          content="Success stories of businesses transforming with our AI solutions"
+        />
+        <meta property="og:url" content={canonicalUrl} />
+        <meta name="twitter:card" content="summary_large_image" />
+        <meta name="twitter:title" content="Case Studies | NEXIUS Labs" />
+        <meta
+          name="twitter:description"
+          content="Success stories of businesses transforming with our AI solutions"
+        />
+      </Helmet>
+      <div className="min-h-screen bg-nexius-dark-bg">
       {/* Hero Section */}
       <section className="relative pt-32 pb-24 bg-gradient-to-b from-nexius-navy to-nexius-navy/95">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
@@ -136,5 +161,6 @@ export function CaseStudies() {
         </div>
       </section>
     </div>
+    </>
   );
 }

--- a/src/pages/CaseStudy.tsx
+++ b/src/pages/CaseStudy.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect } from 'react';
-import { useParams, Link } from 'react-router-dom';
+import { useParams, Link, useLocation } from 'react-router-dom';
 import { ArrowLeft, CheckCircle2, TrendingUp, Users, Target, ArrowRight } from 'lucide-react';
+import { Helmet } from 'react-helmet-async';
 
 interface CaseStudyData {
   title: string;
@@ -184,6 +185,7 @@ const caseStudiesData: Record<string, CaseStudyData> = {
 
 export function CaseStudy() {
   const { id } = useParams<{ id: string }>();
+  const location = useLocation();
   const study = id ? caseStudiesData[id] : null;
 
   // Scroll to top when component mounts
@@ -203,9 +205,24 @@ export function CaseStudy() {
       </div>
     );
   }
+  const canonicalUrl = `https://nexiuslabs.com${location.pathname}`;
 
   return (
-    <div className="min-h-screen bg-nexius-dark-bg">
+    <>
+      <Helmet>
+        <title>{`${study.title} | NEXIUS Labs`}</title>
+        <meta name="description" content={study.description} />
+        <link rel="canonical" href={canonicalUrl} />
+        <meta property="og:title" content={study.title} />
+        <meta property="og:description" content={study.description} />
+        <meta property="og:url" content={canonicalUrl} />
+        <meta property="og:image" content={study.image} />
+        <meta name="twitter:card" content="summary_large_image" />
+        <meta name="twitter:title" content={study.title} />
+        <meta name="twitter:description" content={study.description} />
+        <meta name="twitter:image" content={study.image} />
+      </Helmet>
+      <div className="min-h-screen bg-nexius-dark-bg">
       {/* Hero Section */}
       <div className="relative h-[60vh] min-h-[400px] bg-nexius-navy">
         <div className="absolute inset-0">
@@ -366,5 +383,6 @@ export function CaseStudy() {
         </div>
       </div>
     </div>
+    </>
   );
 }

--- a/src/pages/EventDetail.tsx
+++ b/src/pages/EventDetail.tsx
@@ -1,12 +1,14 @@
 import React, { useState, useEffect } from 'react';
-import { useParams, Link } from 'react-router-dom';
+import { useParams, Link, useLocation } from 'react-router-dom';
 import { supabase } from '../lib/supabase';
 import { Calendar, MapPin, ArrowLeft } from 'lucide-react';
 import { EventRegistrationForm } from '../components/EventRegistrationForm';
 import type { Event } from '../types/database';
+import { Helmet } from 'react-helmet-async';
 
 export function EventDetail() {
   const { slug } = useParams<{ slug: string }>();
+  const location = useLocation();
   const [event, setEvent] = useState<Event | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -75,9 +77,34 @@ export function EventDetail() {
       </div>
     );
   }
+  const canonicalUrl = `https://nexiuslabs.com${location.pathname}`;
 
   return (
-    <div className="min-h-screen bg-nexius-dark-bg">
+    <>
+      <Helmet>
+        <title>{`${event.title} | NEXIUS Labs`}</title>
+        {event.description && (
+          <meta name="description" content={event.description} />
+        )}
+        <link rel="canonical" href={canonicalUrl} />
+        <meta property="og:title" content={event.title} />
+        {event.description && (
+          <meta property="og:description" content={event.description} />
+        )}
+        <meta property="og:url" content={canonicalUrl} />
+        {event.featured_image && (
+          <meta property="og:image" content={event.featured_image} />
+        )}
+        <meta name="twitter:card" content="summary_large_image" />
+        <meta name="twitter:title" content={event.title} />
+        {event.description && (
+          <meta name="twitter:description" content={event.description} />
+        )}
+        {event.featured_image && (
+          <meta name="twitter:image" content={event.featured_image} />
+        )}
+      </Helmet>
+      <div className="min-h-screen bg-nexius-dark-bg">
       {/* Hero Section */}
       <div className="relative bg-nexius-navy py-16">
         <div className="relative max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 h-full">
@@ -186,5 +213,6 @@ export function EventDetail() {
         onClose={() => setShowRegistration(false)}
       />
     </div>
+    </>
   );
 }

--- a/src/pages/Events.tsx
+++ b/src/pages/Events.tsx
@@ -3,12 +3,15 @@ import { supabase } from '../lib/supabase';
 import { EventsList } from '../components/EventsList';
 import { Clock, Calendar } from 'lucide-react';
 import type { Event } from '../types/database';
+import { useLocation } from 'react-router-dom';
+import { Helmet } from 'react-helmet-async';
 
 export default function Events() {
   const [events, setEvents] = useState<Event[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [filter, setFilter] = useState<'upcoming' | 'past'>('upcoming');
+  const location = useLocation();
 
   useEffect(() => {
     loadEvents();
@@ -48,8 +51,31 @@ export default function Events() {
     }
   };
 
+  const canonicalUrl = `https://nexiuslabs.com${location.pathname}`;
+
   return (
-    <div className="min-h-screen bg-nexius-dark-bg">
+    <>
+      <Helmet>
+        <title>Events | NEXIUS Labs</title>
+        <meta
+          name="description"
+          content="Join our workshops, webinars, and conferences focused on AI innovation and business transformation."
+        />
+        <link rel="canonical" href={canonicalUrl} />
+        <meta property="og:title" content="Events | NEXIUS Labs" />
+        <meta
+          property="og:description"
+          content="Join our workshops, webinars, and conferences focused on AI innovation and business transformation."
+        />
+        <meta property="og:url" content={canonicalUrl} />
+        <meta name="twitter:card" content="summary_large_image" />
+        <meta name="twitter:title" content="Events | NEXIUS Labs" />
+        <meta
+          name="twitter:description"
+          content="Join our workshops, webinars, and conferences focused on AI innovation and business transformation."
+        />
+      </Helmet>
+      <div className="min-h-screen bg-nexius-dark-bg">
       {/* Hero Section */}
       <section className="relative pt-32 pb-24 bg-gradient-to-b from-nexius-navy to-nexius-navy/95">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
@@ -140,6 +166,7 @@ export default function Events() {
         </div>
       </section>
     </div>
+    </>
   );
 }
 

--- a/src/pages/LinksPage.tsx
+++ b/src/pages/LinksPage.tsx
@@ -1,6 +1,8 @@
 import React, { useEffect } from 'react';
 import { supabase } from '../lib/supabase';
 import { HeroAnimation } from '../components/HeroAnimation';
+import { useLocation } from 'react-router-dom';
+import { Helmet } from 'react-helmet-async';
 import {
   Globe,
   Mail,
@@ -96,6 +98,7 @@ const links: SocialLink[] = [
 ];
 
 export function LinksPage() {
+  const location = useLocation();
 
   useEffect(() => {
     // Load click counts from Supabase
@@ -129,9 +132,32 @@ export function LinksPage() {
     });
   };
 
+  const canonicalUrl = `https://nexiuslabs.com${location.pathname}`;
+
   return (
-    <div className="min-h-screen bg-gradient-to-b from-nexius-navy to-nexius-navy/95">
-      <HeroAnimation />
+    <>
+      <Helmet>
+        <title>Links | NEXIUS Labs</title>
+        <meta
+          name="description"
+          content="Quick links to connect with NEXIUS Labs online"
+        />
+        <link rel="canonical" href={canonicalUrl} />
+        <meta property="og:title" content="Links | NEXIUS Labs" />
+        <meta
+          property="og:description"
+          content="Quick links to connect with NEXIUS Labs online"
+        />
+        <meta property="og:url" content={canonicalUrl} />
+        <meta name="twitter:card" content="summary_large_image" />
+        <meta name="twitter:title" content="Links | NEXIUS Labs" />
+        <meta
+          name="twitter:description"
+          content="Quick links to connect with NEXIUS Labs online"
+        />
+      </Helmet>
+      <div className="min-h-screen bg-gradient-to-b from-nexius-navy to-nexius-navy/95">
+        <HeroAnimation />
       {/* Header */}
       <header className="pt-12 px-4 sm:px-6 lg:px-8 flex justify-center">
         <div className="text-center">
@@ -255,5 +281,6 @@ export function LinksPage() {
         </p>
       </footer>
     </div>
+    </>
   );
 }

--- a/src/pages/NotFound.tsx
+++ b/src/pages/NotFound.tsx
@@ -1,12 +1,28 @@
 import React from 'react';
-import { Link } from 'react-router-dom';
+import { Link, useLocation } from 'react-router-dom';
 import { Home, ArrowLeft } from 'lucide-react';
+import { Helmet } from 'react-helmet-async';
 
 export function NotFound() {
+  const location = useLocation();
+  const canonicalUrl = `https://nexiuslabs.com${location.pathname}`;
+
   return (
-    <div className="min-h-screen bg-gradient-to-b from-nexius-navy to-nexius-navy/95 flex items-center justify-center px-4">
-      <div className="max-w-md w-full text-center">
-        <img
+    <>
+      <Helmet>
+        <title>Page Not Found | NEXIUS Labs</title>
+        <meta name="description" content="The page you are looking for does not exist." />
+        <link rel="canonical" href={canonicalUrl} />
+        <meta property="og:title" content="Page Not Found | NEXIUS Labs" />
+        <meta property="og:description" content="The page you are looking for does not exist." />
+        <meta property="og:url" content={canonicalUrl} />
+        <meta name="twitter:card" content="summary_large_image" />
+        <meta name="twitter:title" content="Page Not Found | NEXIUS Labs" />
+        <meta name="twitter:description" content="The page you are looking for does not exist." />
+      </Helmet>
+      <div className="min-h-screen bg-gradient-to-b from-nexius-navy to-nexius-navy/95 flex items-center justify-center px-4">
+        <div className="max-w-md w-full text-center">
+          <img
           src="https://tunidbyclygzipvbfzee.supabase.co/storage/v1/object/public/website-images/m04h4fs8wns-1739784195705.png"
           alt="NEXIUS Labs"
           className="h-16 w-16 mx-auto mb-8"
@@ -34,5 +50,6 @@ export function NotFound() {
         </div>
       </div>
     </div>
+    </>
   );
 }

--- a/src/pages/PrivacyPolicy.tsx
+++ b/src/pages/PrivacyPolicy.tsx
@@ -1,10 +1,26 @@
 import React from 'react';
-import { Link } from 'react-router-dom';
+import { Link, useLocation } from 'react-router-dom';
 import { ArrowLeft } from 'lucide-react';
+import { Helmet } from 'react-helmet-async';
 
 export function PrivacyPolicy() {
+  const location = useLocation();
+  const canonicalUrl = `https://nexiuslabs.com${location.pathname}`;
+
   return (
-    <div className="min-h-screen bg-nexius-dark-bg">
+    <>
+      <Helmet>
+        <title>Privacy Policy | NEXIUS Labs</title>
+        <meta name="description" content="Privacy policy for NEXIUS Labs." />
+        <link rel="canonical" href={canonicalUrl} />
+        <meta property="og:title" content="Privacy Policy | NEXIUS Labs" />
+        <meta property="og:description" content="Privacy policy for NEXIUS Labs." />
+        <meta property="og:url" content={canonicalUrl} />
+        <meta name="twitter:card" content="summary_large_image" />
+        <meta name="twitter:title" content="Privacy Policy | NEXIUS Labs" />
+        <meta name="twitter:description" content="Privacy policy for NEXIUS Labs." />
+      </Helmet>
+      <div className="min-h-screen bg-nexius-dark-bg">
       {/* Header */}
       <div className="bg-nexius-navy py-16">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
@@ -162,5 +178,6 @@ export function PrivacyPolicy() {
         </div>
       </div>
     </div>
+    </>
   );
 }

--- a/src/pages/UploadLogo.tsx
+++ b/src/pages/UploadLogo.tsx
@@ -1,16 +1,35 @@
 import React, { useState } from 'react';
 import { ImageUpload } from '../components/ImageUpload';
+import { useLocation } from 'react-router-dom';
+import { Helmet } from 'react-helmet-async';
 
 export function UploadLogo() {
   const [logoUrl, setLogoUrl] = useState<string | null>(null);
   const [uploadType, setUploadType] = useState<'melverick' | 'darryl'>('melverick');
+  const location = useLocation();
+  const canonicalUrl = `https://nexiuslabs.com${location.pathname}`;
 
   const handleUploadComplete = (imageUrl: string) => {
     setLogoUrl(imageUrl);
   };
 
   return (
-    <div className="min-h-screen bg-nexius-dark-bg py-32">
+    <>
+      <Helmet>
+        <title>Upload Co-founder Photos | NEXIUS Labs</title>
+        <meta
+          name="description"
+          content="Upload co-founder photos for NEXIUS Labs."
+        />
+        <link rel="canonical" href={canonicalUrl} />
+        <meta property="og:title" content="Upload Co-founder Photos | NEXIUS Labs" />
+        <meta property="og:description" content="Upload co-founder photos for NEXIUS Labs." />
+        <meta property="og:url" content={canonicalUrl} />
+        <meta name="twitter:card" content="summary_large_image" />
+        <meta name="twitter:title" content="Upload Co-founder Photos | NEXIUS Labs" />
+        <meta name="twitter:description" content="Upload co-founder photos for NEXIUS Labs." />
+      </Helmet>
+      <div className="min-h-screen bg-nexius-dark-bg py-32">
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         <div className="max-w-3xl mx-auto">
           <div className="bg-nexius-dark-surface rounded-lg shadow-sm p-8 border border-nexius-dark-border">
@@ -68,5 +87,6 @@ export function UploadLogo() {
         </div>
       </div>
     </div>
+    </>
   );
 }


### PR DESCRIPTION
## Summary
- integrate `react-helmet-async` and provide `HelmetProvider` at app root
- add per-page metadata (title, description, canonical and social tags)

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ad1de4f56c8320968a586e1432f9f9