### PR TITLE
refactor: centralize base url

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -1,0 +1,1 @@
+export const BASE_URL = 'https://nexiuslabs.com';

--- a/src/pages/BlogPost.tsx
+++ b/src/pages/BlogPost.tsx
@@ -3,12 +3,24 @@ import { useParams, Link, useNavigate } from 'react-router-dom';
 import { supabase } from '../lib/supabase';
 import { ArrowLeft, Calendar, User, Clock } from 'lucide-react';
 import type { Article } from '../types/database';
+import { BASE_URL } from '../config';
 
 export function BlogPost() {
   const { slug } = useParams<{ slug: string }>();
   const navigate = useNavigate();
   const [article, setArticle] = useState<Article | null>(null);
   const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    if (article) {
+      const canonical = document.querySelector("link[rel='canonical']") || document.createElement('link');
+      canonical.setAttribute('rel', 'canonical');
+      canonical.setAttribute('href', `${BASE_URL}/blog/${article.slug}`);
+      if (!canonical.parentNode) {
+        document.head.appendChild(canonical);
+      }
+    }
+  }, [article]);
 
   useEffect(() => {
     loadArticle();
@@ -57,10 +69,12 @@ export function BlogPost() {
   if (!article) {
     return null;
   }
+  const canonicalUrl = `${BASE_URL}/blog/${article.slug}`;
   const jsonLd = {
     '@context': 'https://schema.org',
     '@type': 'Article',
     headline: article.title,
+    url: canonicalUrl,
     datePublished: article.published_at || article.created_at,
     image: article.featured_image,
     author: {

--- a/src/pages/EventDetail.tsx
+++ b/src/pages/EventDetail.tsx
@@ -4,6 +4,7 @@ import { supabase } from '../lib/supabase';
 import { Calendar, MapPin, ArrowLeft } from 'lucide-react';
 import { EventRegistrationForm } from '../components/EventRegistrationForm';
 import type { Event } from '../types/database';
+import { BASE_URL } from '../config';
 
 export function EventDetail() {
   const { slug } = useParams<{ slug: string }>();
@@ -15,6 +16,17 @@ export function EventDetail() {
   useEffect(() => {
     loadEvent();
   }, [slug]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  useEffect(() => {
+    if (event) {
+      const canonical = document.querySelector("link[rel='canonical']") || document.createElement('link');
+      canonical.setAttribute('rel', 'canonical');
+      canonical.setAttribute('href', `${BASE_URL}/events/${event.slug}`);
+      if (!canonical.parentNode) {
+        document.head.appendChild(canonical);
+      }
+    }
+  }, [event]);
 
   const loadEvent = async () => {
     try {
@@ -75,10 +87,12 @@ export function EventDetail() {
       </div>
     );
   }
+  const canonicalUrl = `${BASE_URL}/events/${event.slug}`;
   const jsonLd = {
     '@context': 'https://schema.org',
     '@type': 'Event',
     name: event.title,
+    url: canonicalUrl,
     startDate: event.start_date,
     endDate: event.end_date,
     location: {

--- a/src/pages/LinksPage.tsx
+++ b/src/pages/LinksPage.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect } from 'react';
 import { supabase } from '../lib/supabase';
 import { HeroAnimation } from '../components/HeroAnimation';
+import { BASE_URL } from '../config';
 import {
   Globe,
   Mail,
@@ -75,7 +76,7 @@ const links: SocialLink[] = [
   {
     id: '2',
     title: 'Visit Our Website',
-    url: 'https://nexiuslabs.com',
+    url: BASE_URL,
     type: 'external',
     icon: 'website',
   },


### PR DESCRIPTION
## Summary
- add shared BASE_URL config
- use BASE_URL in link page
- compute canonical URLs in BlogPost and EventDetail using BASE_URL

## Testing
- `npx -y vitest run`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ad211525b88320b43dd0518c2470a5