### PR TITLE
Fix chat initialization hook ordering

### DIFF
--- a/src/components/Chat.tsx
+++ b/src/components/Chat.tsx
@@ -41,6 +41,25 @@ export function Chat() {
     }
   };
 
+  const initializeChat = useCallback(async () => {
+    setLoading(true);
+    try {
+      const session = await createChatSession({
+        visitor_id: visitorId,
+      });
+
+      setSessionId(session.id);
+
+      // Fetch initial messages
+      const messages = await getChatMessages(session.id);
+      setMessages(messages);
+    } catch (error) {
+      console.error('Error initializing chat:', error);
+    } finally {
+      setLoading(false);
+    }
+  }, [visitorId]);
+
   useEffect(() => {
     // Generate a unique visitor ID if not exists
     const storedVisitorId = localStorage.getItem('visitorId');
@@ -100,25 +119,6 @@ export function Chat() {
       scrollToBottom();
     }
   }, [messages]);
-
-  const initializeChat = useCallback(async () => {
-    setLoading(true);
-    try {
-      const session = await createChatSession({
-        visitor_id: visitorId,
-      });
-      
-      setSessionId(session.id);
-      
-      // Fetch initial messages
-      const messages = await getChatMessages(session.id);
-      setMessages(messages);
-    } catch (error) {
-      console.error('Error initializing chat:', error);
-    } finally {
-      setLoading(false);
-    }
-  }, [visitorId]);
 
   const scrollToBottom = () => {
     if (messageContainerRef.current) {


### PR DESCRIPTION
## Summary
- Place `initializeChat` callback before any effects using it
- Keep `initializeChat` in dependency array of the effect that triggers it

## Testing
- `npm test`
- `npx vitest run tests/chat-widget.test.tsx --environment jsdom`


------
https://chatgpt.com/codex/tasks/task_e_68ad30c29c6c83209c9da1d178613874