### PR TITLE
chore: restrict crawling of private pages

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -16,6 +16,10 @@ Disallow: /*?gclid=*
 Disallow: /index.html
 Disallow: /index.php
 
+# Block private routes
+Disallow: /admin
+Disallow: /upload
+
 # Allow important files
 Allow: /sitemap.xml
 Allow: /robots.txt

--- a/src/pages/AdminPage.tsx
+++ b/src/pages/AdminPage.tsx
@@ -88,6 +88,16 @@ export default function AdminPage() {
   const [editingArticle, setEditingArticle] = useState<Article | null>(null);
   const [showImageUpload, setShowImageUpload] = useState(false);
 
+  useEffect(() => {
+    const meta = document.createElement('meta');
+    meta.name = 'robots';
+    meta.content = 'noindex,nofollow';
+    document.head.appendChild(meta);
+    return () => {
+      document.head.removeChild(meta);
+    };
+  }, []);
+
   // State for modals
   const [showAddProduct, setShowAddProduct] = useState(false);
   const [showAddCourse, setShowAddCourse] = useState(false);

--- a/src/pages/UploadLogo.tsx
+++ b/src/pages/UploadLogo.tsx
@@ -1,9 +1,19 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { ImageUpload } from '../components/ImageUpload';
 
 export function UploadLogo() {
   const [logoUrl, setLogoUrl] = useState<string | null>(null);
   const [uploadType, setUploadType] = useState<'melverick' | 'darryl'>('melverick');
+
+  useEffect(() => {
+    const meta = document.createElement('meta');
+    meta.name = 'robots';
+    meta.content = 'noindex,nofollow';
+    document.head.appendChild(meta);
+    return () => {
+      document.head.removeChild(meta);
+    };
+  }, []);
 
   const handleUploadComplete = (imageUrl: string) => {
     setLogoUrl(imageUrl);


### PR DESCRIPTION
## Summary
- add noindex/nofollow meta tag to admin and upload pages
- disallow admin and upload routes in robots.txt

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: 78 errors, 5 warnings)


------
https://chatgpt.com/codex/tasks/task_e_68ad352612e08320bc979a4a889daed9