### PR TITLE
Add social and Twitter meta tags with dynamic route updates

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,6 +4,15 @@
     <meta charset="UTF-8" />
     <meta name="description" content="Nexius Labs specializes in AI-powered business automation, process optimization, and no-code solutions to help businesses scale efficiently." />
     <link rel="canonical" href="https://nexiuslabs.com/" />
+    <meta property="og:title" content="NEXIUS Labs | AI-Powered Executive Intelligence Platform" />
+    <meta property="og:description" content="Nexius Labs specializes in AI-powered business automation, process optimization, and no-code solutions to help businesses scale efficiently." />
+    <meta property="og:image" content="https://tunidbyclygzipvbfzee.supabase.co/storage/v1/object/public/website-images/nexius_logo_no_text_transparent_bg.png" />
+    <meta property="og:url" content="https://nexiuslabs.com/" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="NEXIUS Labs | AI-Powered Executive Intelligence Platform" />
+    <meta name="twitter:description" content="Nexius Labs specializes in AI-powered business automation, process optimization, and no-code solutions to help businesses scale efficiently." />
+    <meta name="twitter:image" content="https://tunidbyclygzipvbfzee.supabase.co/storage/v1/object/public/website-images/nexius_logo_no_text_transparent_bg.png" />
+    <meta name="twitter:url" content="https://nexiuslabs.com/" />
     <!-- Google tag (gtag.js) -->
     <script async src="https://www.googletagmanager.com/gtag/js?id=G-DH3J7GNR72"></script>
     <script>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -50,6 +50,7 @@ import { NotFound } from './pages/NotFound';
 import { Chat } from './components/Chat';
 import { AgentPage } from './pages/AgentPage';
 import { AboutUs } from './pages/AboutUs';
+import { MetadataManager } from './lib/metadata';
 
 const features = [
   {
@@ -575,6 +576,7 @@ export default function App() {
 
   return (
     <>
+      <MetadataManager />
       {shouldShowNav && <Navigation onContactClick={() => setIsContactFormOpen(true)} />}
       <ContactForm isOpen={isContactFormOpen} onClose={() => setIsContactFormOpen(false)} />
 

--- a/src/lib/metadata.tsx
+++ b/src/lib/metadata.tsx
@@ -1,0 +1,99 @@
+import { useEffect } from 'react';
+import { useLocation } from 'react-router-dom';
+
+export interface MetaTags {
+  title: string;
+  description: string;
+  image?: string;
+  url?: string;
+}
+
+export const defaultMeta: MetaTags = {
+  title: 'NEXIUS Labs | AI-Powered Executive Intelligence Platform',
+  description:
+    'Nexius Labs specializes in AI-powered business automation, process optimization, and no-code solutions to help businesses scale efficiently.',
+  image:
+    'https://tunidbyclygzipvbfzee.supabase.co/storage/v1/object/public/website-images/nexius_logo_no_text_transparent_bg.png',
+  url: 'https://nexiuslabs.com/',
+};
+
+export const metaByRoute: Record<string, MetaTags> = {
+  '/': defaultMeta,
+  '/aboutus': {
+    ...defaultMeta,
+    title: 'About Us | NEXIUS Labs',
+    url: 'https://nexiuslabs.com/aboutus',
+  },
+  '/case-studies': {
+    ...defaultMeta,
+    title: 'Case Studies | NEXIUS Labs',
+    url: 'https://nexiuslabs.com/case-studies',
+  },
+  '/blog': {
+    ...defaultMeta,
+    title: 'Blog | NEXIUS Labs',
+    url: 'https://nexiuslabs.com/blog',
+  },
+  '/events': {
+    ...defaultMeta,
+    title: 'Events | NEXIUS Labs',
+    url: 'https://nexiuslabs.com/events',
+  },
+  '/privacy': {
+    ...defaultMeta,
+    title: 'Privacy Policy | NEXIUS Labs',
+    url: 'https://nexiuslabs.com/privacy',
+  },
+  '/terms': {
+    ...defaultMeta,
+    title: 'Terms of Service | NEXIUS Labs',
+    url: 'https://nexiuslabs.com/terms',
+  },
+};
+
+export function updateMetaTags(meta: MetaTags) {
+  document.title = meta.title;
+  const tags: { name?: string; property?: string; content: string }[] = [
+    { name: 'description', content: meta.description },
+    { property: 'og:title', content: meta.title },
+    { property: 'og:description', content: meta.description },
+    { property: 'og:image', content: meta.image || defaultMeta.image! },
+    { property: 'og:url', content: meta.url || window.location.href },
+    { name: 'twitter:card', content: 'summary_large_image' },
+    { name: 'twitter:title', content: meta.title },
+    { name: 'twitter:description', content: meta.description },
+    { name: 'twitter:image', content: meta.image || defaultMeta.image! },
+    { name: 'twitter:url', content: meta.url || window.location.href },
+  ];
+
+  tags.forEach(({ name, property, content }) => {
+    let element: HTMLMetaElement | null = null;
+    if (name) {
+      element = document.querySelector(`meta[name="${name}"]`);
+    } else if (property) {
+      element = document.querySelector(`meta[property="${property}"]`);
+    }
+    if (!element) {
+      element = document.createElement('meta');
+      if (name) {
+        element.setAttribute('name', name);
+      } else if (property) {
+        element.setAttribute('property', property);
+      }
+      document.head.appendChild(element);
+    }
+    element.setAttribute('content', content);
+  });
+}
+
+export function MetadataManager() {
+  const location = useLocation();
+
+  useEffect(() => {
+    const meta = metaByRoute[location.pathname] || defaultMeta;
+    updateMetaTags(meta);
+  }, [location.pathname]);
+
+  return null;
+}
+

--- a/src/pages/BlogPost.tsx
+++ b/src/pages/BlogPost.tsx
@@ -3,6 +3,7 @@ import { useParams, Link, useNavigate } from 'react-router-dom';
 import { supabase } from '../lib/supabase';
 import { ArrowLeft, Calendar, User, Clock } from 'lucide-react';
 import type { Article } from '../types/database';
+import { updateMetaTags, defaultMeta } from '../lib/metadata';
 
 export function BlogPost() {
   const { slug } = useParams<{ slug: string }>();
@@ -37,6 +38,17 @@ export function BlogPost() {
       setLoading(false);
     }
   };
+
+  useEffect(() => {
+    if (article) {
+      updateMetaTags({
+        title: article.title,
+        description: article.description || defaultMeta.description,
+        image: article.featured_image || defaultMeta.image,
+        url: `https://nexiuslabs.com/blog/${article.slug || slug}`,
+      });
+    }
+  }, [article, slug]);
 
   const formatDate = (date: string) => {
     return new Date(date).toLocaleDateString('en-US', {

--- a/src/pages/EventDetail.tsx
+++ b/src/pages/EventDetail.tsx
@@ -5,6 +5,7 @@ import { supabase } from '../lib/supabase';
 import { Calendar, Clock, MapPin, Users, ArrowLeft } from 'lucide-react';
 import { EventRegistrationForm } from '../components/EventRegistrationForm';
 import type { Event } from '../types/database';
+import { updateMetaTags, defaultMeta } from '../lib/metadata';
 
 export function EventDetail() {
   const { slug } = useParams<{ slug: string }>();
@@ -37,6 +38,18 @@ export function EventDetail() {
       setLoading(false);
     }
   };
+
+  useEffect(() => {
+    if (event) {
+      updateMetaTags({
+        title: event.title,
+        description:
+          event.description?.replace(/<[^>]+>/g, '') || defaultMeta.description,
+        image: event.featured_image || defaultMeta.image,
+        url: `https://nexiuslabs.com/event/${event.slug || slug}`,
+      });
+    }
+  }, [event, slug]);
 
   const formatDateTime = (date: string) => {
     return new Date(date).toLocaleString('en-US', {


### PR DESCRIPTION
## Summary
- add Open Graph and Twitter meta tags to base HTML
- introduce metadata manager to update SEO tags per route
- update blog post and event pages to set metadata dynamically

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: 86 problems (78 errors, 8 warnings))*

------
https://chatgpt.com/codex/tasks/task_e_68ad352229f48320b0b73ae4b60347a6